### PR TITLE
Updated readme for Laravel 4.3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installation
 Begin by installing this package through Composer. Edit your project's `composer.json` file to require `davispeixoto/laravel-salesforce`.
 
     "require": {
-        "laravel/framework": "4.2.*",
+        "laravel/framework": "5.0.*@dev",
         "davispeixoto/laravel-salesforce": "2.0.0"
     }
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "4.*",
+        "illuminate/support": "5.0*@dev",
         "davispeixoto/force-dot-com-toolkit-for-php": "1.0.3"
     },
     "autoload": {


### PR DESCRIPTION
The README is a little outdated so at the very least lines 11-14, 33-38, 47 would be nice to change for Laravel 4.2.

For 4.3 I updated the `artisan` command as well as the path for the config folder. Maybe it would be good to keep this in a dev branch until 4.3 is released in November?
