### PR TITLE
Fixing FatalErrorException of Salesfoce.php adding a missing use \Log;

### DIFF
--- a/src/Davispeixoto/LaravelSalesforce/Salesforce.php
+++ b/src/Davispeixoto/LaravelSalesforce/Salesforce.php
@@ -2,6 +2,7 @@
 
 use Davispeixoto\ForceDotComToolkitForPhp\SforceEnterpriseClient as Client;
 use Illuminate\Config\Repository;
+use \Log;
 
 /**
  * Class Salesforce


### PR DESCRIPTION
That's a tiny fix, I found this error because I was using a wrong username to login.